### PR TITLE
change method for getting url's status code

### DIFF
--- a/src/Url/Scanner.php
+++ b/src/Url/Scanner.php
@@ -55,7 +55,7 @@ class Scanner
      */
     protected function getStatusCodeForUrl($url)
     {
-        $httpResponse = $this->httpClient->options($url);
+        $httpResponse = $this->httpClient->get($url);
 
         return $httpResponse->getStatusCode();
     }


### PR DESCRIPTION
Now 'google.com' is not invalid.
